### PR TITLE
fix: stop deleting firm_weekly_reports during retention cleanup

### DIFF
--- a/scripts/backfill-firm-trustpilot-reviews.ts
+++ b/scripts/backfill-firm-trustpilot-reviews.ts
@@ -34,7 +34,6 @@ const REVIEWS_RETENTION_DAYS = parseInt(
   10
 );
 const INCIDENTS_RETENTION_DAYS = 30;
-const REPORTS_RETENTION_DAYS = 30;
 
 function daysAgo(days: number): string {
   const d = new Date();
@@ -68,15 +67,6 @@ async function runRetentionCleanup() {
   if (errIncidents) throw new Error(`firm_daily_incidents cleanup: ${errIncidents.message}`);
   console.log(`[Trustpilot Backfill] firm_daily_incidents: deleted ${deletedIncidents?.length ?? 0} rows`);
 
-  const reportsCutoff = new Date();
-  reportsCutoff.setUTCDate(reportsCutoff.getUTCDate() - REPORTS_RETENTION_DAYS);
-  const { data: deletedReports, error: errReports } = await supabase
-    .from('firm_weekly_reports')
-    .delete()
-    .lt('generated_at', reportsCutoff.toISOString())
-    .select('id');
-  if (errReports) throw new Error(`firm_weekly_reports cleanup: ${errReports.message}`);
-  console.log(`[Trustpilot Backfill] firm_weekly_reports: deleted ${deletedReports?.length ?? 0} rows`);
 }
 
 async function updateFirmScraperStatus(


### PR DESCRIPTION
## Summary
- Removes the `firm_weekly_reports` deletion block from the daily Trustpilot retention cleanup
- Removes unused `REPORTS_RETENTION_DAYS` constant
- Weekly reports are aggregated historical data required for the upcoming Trustpilot Score Momentum feature (S10-008, S10-009) — they must be kept indefinitely, not pruned with the 30-day raw review window

## Test plan
- [x] All 647 existing tests pass
- [x] `runRetentionCleanup()` still correctly prunes `firm_trustpilot_reviews` (30d) and `firm_daily_incidents` (30d)
- [x] `firm_weekly_reports` rows are no longer touched by the cleanup script

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)