### PR TITLE
[S10-002] Extend topic card references from 3 to 6

### DIFF
--- a/app/api/v2/propfirms/[id]/incidents/route.js
+++ b/app/api/v2/propfirms/[id]/incidents/route.js
@@ -123,7 +123,7 @@ export async function GET(request, { params }) {
     .map((r) => {
       const ids = Array.isArray(r.review_ids) ? r.review_ids : [];
       const source_links = ids
-        .slice(0, 3)
+        .slice(0, 6)
         .map((id) => {
           const info = idToInfo[id];
           if (!info?.url) return null;

--- a/app/propfirms/[id]/intelligence/page.js
+++ b/app/propfirms/[id]/intelligence/page.js
@@ -69,7 +69,7 @@ function incidentToItem(inc) {
   const rawLinks = inc.source_links || [];
   const cardDateRaw = inc.evidence_date || inc.week_start || "";
   const cardDate = cardDateRaw ? formatDisplayDate(cardDateRaw) : "";
-  const sources = rawLinks.slice(0, 3).map((item, i) => {
+  const sources = rawLinks.slice(0, 6).map((item, i) => {
     const url = typeof item === "string" ? item : item?.url;
     const sourceDate = typeof item === "object" && item?.date ? item.date : cardDateRaw;
     const { label, domain } = getLabelAndDomainFromUrl(url || "", i);

--- a/components/propfirms/intelligence/IntelligenceCard.js
+++ b/components/propfirms/intelligence/IntelligenceCard.js
@@ -75,7 +75,7 @@ export default function IntelligenceCard({ item }) {
               References:
             </span>
             <div className="flex flex-wrap gap-1.5">
-              {item.sources.slice(0, 3).map((source) => (
+              {item.sources.slice(0, 6).map((source) => (
                 <a
                   key={source.id}
                   href={source.url}


### PR DESCRIPTION
Extends source references per grouped topic card from 3 to 6 in the intelligence feed.

Changes:
- `app/api/v2/propfirms/[id]/incidents/route.js`: `.slice(0, 3)` → `.slice(0, 6)`
- `components/propfirms/intelligence/IntelligenceCard.js`: `.slice(0, 3)` → `.slice(0, 6)`
- `app/propfirms/[id]/intelligence/page.js`: `.slice(0, 3)` → `.slice(0, 6)`

Closes #15

Generated with [Claude Code](https://claude.ai/code)