### PR TITLE
feat: composite signal ranking and feed limit for intelligence feed

### DIFF
--- a/app/api/v2/propfirms/[id]/incidents/route.js
+++ b/app/api/v2/propfirms/[id]/incidents/route.js
@@ -38,8 +38,10 @@ export async function GET(request, { params }) {
   const start = Date.now();
   const { searchParams } = new URL(request.url);
   const days = Math.min(365, Math.max(1, parseInt(searchParams.get('days') || '90', 10) || 90));
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 0) : null;
 
-  log.info({ method: 'GET', params: { days } }, 'API request');
+  log.info({ method: 'GET', params: { days, limit } }, 'API request');
 
   const { ok, headers } = validateOrigin(request);
   setRequestIdHeader(headers, requestId);
@@ -141,6 +143,20 @@ export async function GET(request, { params }) {
       return db.localeCompare(da);
     });
 
-  log.info({ duration: Date.now() - start, count: incidentsWithLinks.length }, 'API response');
-  return NextResponse.json({ incidents: incidentsWithLinks }, { headers });
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
+  const recentCutoff = sevenDaysAgo.toISOString().slice(0, 10);
+
+  function compositeScore(incident) {
+    const severityWeight = incident.severity === 'high' ? 3 : incident.severity === 'medium' ? 2 : 1;
+    const reviewCountWeight = incident.review_count || 0;
+    const recencyBoost = incident.evidence_date && incident.evidence_date >= recentCutoff ? 1 : 0;
+    return severityWeight + reviewCountWeight + recencyBoost;
+  }
+
+  const ranked = incidentsWithLinks.sort((a, b) => compositeScore(b) - compositeScore(a));
+  const result = limit ? ranked.slice(0, limit) : ranked;
+
+  log.info({ duration: Date.now() - start, count: result.length }, 'API response');
+  return NextResponse.json({ incidents: result }, { headers });
 }

--- a/app/api/v2/propfirms/[id]/incidents/route.test.js
+++ b/app/api/v2/propfirms/[id]/incidents/route.test.js
@@ -219,6 +219,102 @@ describe('GET /api/v2/propfirms/[id]/incidents', () => {
     expect(body.incidents[0].source_links).toEqual([]);
   });
 
+  it('respects ?limit param and returns only N incidents', async () => {
+    const manyIncidents = [1, 2, 3, 4, 5].map((n) => ({
+      id: n,
+      firm_id: 'f1',
+      week_number: 7,
+      year: 2025,
+      incident_type: 'payout_delay',
+      severity: 'medium',
+      title: `Incident ${n}`,
+      summary: 'S',
+      review_count: n,
+      affected_users: 0,
+      review_ids: [],
+      created_at: new Date().toISOString(),
+    }));
+    withQueryGuard.mockResolvedValueOnce({ data: manyIncidents, error: null });
+    const req = createRequest('https://x.com/api/v2/propfirms/f1/incidents?days=90&limit=2');
+    const res = await GET(req, { params: Promise.resolve({ id: 'f1' }) });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.incidents).toHaveLength(2);
+  });
+
+  it('returns all incidents when no ?limit param is provided', async () => {
+    const manyIncidents = [1, 2, 3].map((n) => ({
+      id: n,
+      firm_id: 'f1',
+      week_number: 7,
+      year: 2025,
+      incident_type: 'payout_delay',
+      severity: 'medium',
+      title: `Incident ${n}`,
+      summary: 'S',
+      review_count: 1,
+      affected_users: 0,
+      review_ids: [],
+      created_at: new Date().toISOString(),
+    }));
+    withQueryGuard.mockResolvedValueOnce({ data: manyIncidents, error: null });
+    const req = createRequest('https://x.com/api/v2/propfirms/f1/incidents?days=90');
+    const res = await GET(req, { params: Promise.resolve({ id: 'f1' }) });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.incidents).toHaveLength(3);
+  });
+
+  it('ranks high-severity incident above low-severity recent one via composite score', async () => {
+    // Incident A: low severity, recent date → score = 1 + 0 + 1 = 2
+    // Incident B: high severity, high review_count, old date → score = 3 + 5 + 0 = 8
+    // Incident B should rank first despite older evidence_date
+    const twoIncidents = [
+      {
+        id: 20,
+        firm_id: 'f1',
+        week_number: 7,
+        year: 2025,
+        incident_type: 'other',
+        severity: 'low',
+        title: 'Low severity recent',
+        summary: 'S',
+        review_count: 0,
+        affected_users: 0,
+        review_ids: ['rev-recent'],
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: 21,
+        firm_id: 'f1',
+        week_number: 1,
+        year: 2025,
+        incident_type: 'high_risk_allegation',
+        severity: 'high',
+        title: 'High severity old',
+        summary: 'S',
+        review_count: 5,
+        affected_users: 10,
+        review_ids: ['rev-old'],
+        created_at: new Date().toISOString(),
+      },
+    ];
+    withQueryGuard
+      .mockResolvedValueOnce({ data: twoIncidents, error: null })
+      .mockResolvedValueOnce({
+        data: [
+          { id: 'rev-recent', trustpilot_url: 'https://t.com/recent', review_date: '2025-02-14' },
+          { id: 'rev-old', trustpilot_url: 'https://t.com/old', review_date: '2025-01-01' },
+        ],
+      });
+    const res = await GET(createRequest(), { params: Promise.resolve({ id: 'f1' }) });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.incidents).toHaveLength(2);
+    expect(body.incidents[0].title).toBe('High severity old');
+    expect(body.incidents[1].title).toBe('Low severity recent');
+  });
+
   it('sorts incidents by evidence_date descending (mixed dates and null)', async () => {
     const twoIncidents = [
       {

--- a/app/propfirms/[id]/intelligence/page.js
+++ b/app/propfirms/[id]/intelligence/page.js
@@ -145,7 +145,7 @@ export default function PropFirmIntelligencePage() {
     if (!firmId) return;
     let cancelled = false;
     setLoading(true);
-    fetch(`/api/v2/propfirms/${firmId}/incidents?days=30`)
+    fetch(`/api/v2/propfirms/${firmId}/incidents?days=30&limit=8`)
       .then((r) => (r.ok ? r.json() : { incidents: [] }))
       .then((data) => {
         if (!cancelled) setIncidents(data.incidents || []);


### PR DESCRIPTION
## Summary
- Adds composite ranking score to the incidents API: `severity_weight + review_count + recency_boost`
- High severity incidents with many source reviews surface above low-signal recent ones
- Adds `?limit` query param to the incidents API (backwards compatible — no default limit)
- Intelligence feed page now requests `?days=30&limit=8` to show top 8 signals

## Ranking Formula
```
score = severity_weight + review_count + recency_boost
severity_weight: high=3, medium=2, low=1
recency_boost: +1 if evidence_date within last 7 days
```

## Test plan
- [x] All 647 existing tests pass
- [x] New test: `?limit=2` returns only 2 incidents from 5
- [x] New test: no `?limit` returns all incidents
- [x] New test: high-severity old incident ranks above low-severity recent one
- [x] Existing type filters (OPERATIONAL / REPUTATION) still work correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)